### PR TITLE
NECO-137 removed unnecessary compile setting.

### DIFF
--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -20,7 +20,6 @@ android {
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
     testCompile 'junit:junit:4.12'
     compile 'com.android.support:appcompat-v7:23.4.0'
     compile 'com.android.support:design:23.4.0'


### PR DESCRIPTION
## Ticket

[NECO-137](https://pflabo.atlassian.net/browse/NECO-137)
## Changes
- Removed unnecessary compile setting of `compile fileTree(dir: 'libs', include: ['*.jar'])`.
  - Because `sample/libs` directory does not exist.
## Tests
- Tested the sample app can run normally with [README](https://github.com/hishida/auth-java/blob/master/sample/README.md) procedure.
  Screen shot is in [ticket](https://pflabo.atlassian.net/browse/NECO-137).
